### PR TITLE
Add dropped coords to sliced NDCube

### DIFF
--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -228,7 +228,7 @@ def _wcs_slicer(wcs, missing_axis, item, numpy_order=True):
         raise TypeError("item type is {0}.  Must be int, slice, or tuple of ints and/or slices.".format(type(item)))
     # returning the reverse list of missing axis as in the item here was reverse of
     # what was inputed so we had a reverse missing_axis.
-    dropped_coords = [] # Initiating new list to collect dropped coords in the process of slicing.
+    dropped_coords = {} # Initiating new list to collect dropped coords in the process of slicing.
     # Checking item_ slices for dropped axes if any.
     for i, slice_element in enumerate(item_):
         if missing_axis[i] is False:
@@ -258,7 +258,7 @@ def _wcs_slicer(wcs, missing_axis, item, numpy_order=True):
                 axis_name = wcs_ivoa_mapping[wcs.wcs.ctype[i]]
                 # Added an index to get the axis name for the i-th element of wcs's ctype list.
                 # CTYPE name now mapped to its IVOA counterpart.
-                dropped_coords.append((axis_name, i, real_world_coords))
+                dropped_coords[axis_name] = {"wcs axis": i, "value": real_world_coords}
                 # The dropped_coords's first variable is the IVOA axis name corresponding to the CTYPE.
                 missing_axis[i] = True
     # Use item_ to slice WCS. As item order is always forced to be in WCS order at the start of this function,

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -129,7 +129,8 @@ def _wcs_slicer(wcs, missing_axis, item, numpy_order=True):
         Indicates which axes of the WCS are "missing", i.e. do not correspond to a data axis.
 
     item: `int`, `slice` or `tuple` of `int` and/or `slice`.
-        Slicing item.  If numpy_order=True, the axes must be in a reversed order to those in the wcs input.
+        Slicing item.
+        If numpy_order=True, the axes must be in a reversed order to those in the wcs input.
         If numpy_order=False, the axes must be entered in the same order as those in the wcs input.
 
     numpy_order: bool
@@ -225,7 +226,8 @@ def _wcs_slicer(wcs, missing_axis, item, numpy_order=True):
             # this will make all the item in item_checked as slice.
             item_ = _slice_list(item_checked)
     else:
-        raise TypeError("item type is {0}.  Must be int, slice, or tuple of ints and/or slices.".format(type(item)))
+        raise TypeError("item type is {0}.  ".format(type(item)) + \
+                        "Must be int, slice, or tuple of ints and/or slices.")
     # returning the reverse list of missing axis as in the item here was reverse of
     # what was inputed so we had a reverse missing_axis.
     dropped_coords = {} # Initiating new list to collect dropped coords in the process of slicing.
@@ -239,30 +241,32 @@ def _wcs_slicer(wcs, missing_axis, item, numpy_order=True):
                 slice_start = slice_element.start
             # Determine the stop index.
             if slice_element.stop is None:
-                slice_stop = wcs.pixel_shape[i]  # wcs._pixel_shape is a list of the length of each axis. 
+                # wcs._pixel_shape is a list of the length of each axis.
+                slice_stop = wcs.pixel_shape[i]
             else:
                 slice_stop = slice_element.stop
             # Determine the slice's step.
-            # (We will use this is a later version of this code to be more thorough.  For now we'll calculate it and not use it.)
+            # (We will use this is a later version of this code to be more thorough.
+            # For now we'll calculate it and not use it.)
             if slice_element.step is None:
                 slice_step = 1
             else:
                 slice_step = slice_element.step
             if slice_stop - slice_start == 1:
-                pix_coords = [0] * len(item_)  # Setting up a list of pixel coords as input to all_pix2world.
-                pix_coords[i] = slice_element.start  # Enter pixel coordinate for this axis.
-                # Since we are only dealing with independent axes the other axes can remain at 0.
+                # Set up a list of pixel coords as input to all_pix2world.
+                pix_coords = [0] * len(item_)
+                # Enter pixel coordinate for this axis.
+                pix_coords[i] = slice_element.start
+                # Get real world coordinates of i-th axis.
                 real_world_coords = wcs.all_pix2world(*pix_coords, 0)[i]
-                # Unravel the arguments in the pix_coords array using the * prefix.
-                # Added in index to obtain the i-th element in the resultant real world coords list of arrays.
+                # Get IVOA axis name from CTYPE.
                 axis_name = wcs_ivoa_mapping[wcs.wcs.ctype[i]]
-                # Added an index to get the axis name for the i-th element of wcs's ctype list.
-                # CTYPE name now mapped to its IVOA counterpart.
+                # Add dropped coordinate's name, axis and value to dropped_coords dict of dicts.
                 dropped_coords[axis_name] = {"wcs axis": i, "value": real_world_coords}
-                # The dropped_coords's first variable is the IVOA axis name corresponding to the CTYPE.
                 missing_axis[i] = True
-    # Use item_ to slice WCS. As item order is always forced to be in WCS order at the start of this function,
-    # numpy_order here should always be False.
+    # Use item_ to slice WCS.
+    # As item order is always forced to be in WCS order at the start of this function,
+    # numpy_order here should always be set to False here.
     new_wcs = wcs.slice(item_, numpy_order=False)
     return new_wcs, missing_axis, dropped_coords
 


### PR DESCRIPTION
This PR does two things:
1. It adds ```NDCubeSlicingMixin```'s own ```__getitem__``` rather than using the inherited version from ```NDSlicingMixin```.  For this to work, the format of ```dropped_coords``` has been changed from a list of tuples to a dictionary of dictionaries, i.e. the same format as ```extra_coords``` output.
2. It alters some comments in ```_wcs_slicer``` so there are less than 100 characters in each line as required by the PEP8 Python style guide.
