### PR TITLE
Rewrite _wcs_slicer.

### DIFF
--- a/ndcube/mixins/ndslicing.py
+++ b/ndcube/mixins/ndslicing.py
@@ -68,7 +68,7 @@ class NDCubeSlicingMixin(NDSlicingMixin):
         # here missing axis is reversed as the item comes already in the reverse order
         # of the input
         return utils.wcs._wcs_slicer(
-            self.wcs, copy.deepcopy(self.missing_axis[::-1]), item)
+            self.wcs, copy.deepcopy(self.missing_axis), item)
 
     def _slice_extra_coords(self, item, missing_axis):
         if self.extra_coords is None:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
This PR rewrites ```_wcs_slicer``` to:
* tidy up the code and make easier to follow
* Add more comments to make clear why things are being done.
* clarify API, particularly what order ```item``` and ```missing_axes``` must be in.

This code has not been tested.  That needs to be done before merging into main repo.  Because the API has been clarified, it may also have changed.  So code elsewhere that calls this function might required a few changes elsewhere.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->
